### PR TITLE
Fix Docs Theme and Release Version

### DIFF
--- a/.pyup.yml
+++ b/.pyup.yml
@@ -1,7 +1,7 @@
 update: all
 pin: True
 branch: development
-schedule: "every week"
+schedule: "every week on monday"
 assignees: 
   - jambonrose
 branch_prefix: update/

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,7 +2,7 @@
 History
 =======
 
-2.0.1 (2017-04-19)
+2.1.0 (2017-04-19)
 ------------------
     - Integrate PyUp
     - Write documentation in Sphinx

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,6 +20,7 @@
 # import os
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
+import sphinx_rtd_theme
 
 
 # -- General configuration ------------------------------------------------
@@ -83,7 +84,8 @@ todo_include_todos = False
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'alabaster'
+html_theme = "sphinx_rtd_theme"
+html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
@@ -152,6 +154,3 @@ texinfo_documents = [
      author, 'MarkdownSubscript', 'One line description of project.',
      'Miscellaneous'),
 ]
-
-
-

--- a/requirements/dev_requirements.txt
+++ b/requirements/dev_requirements.txt
@@ -2,6 +2,7 @@ bumpversion==0.5.3
 docutils==0.13.1
 flake8==3.3.0
 sphinx-autobuild==0.6.0
+sphinx-rtd-theme==0.2.4
 sphinx==1.5.5
 tox==2.7.0
 twine==1.8.1


### PR DESCRIPTION
- Use the [Read the Docs theme](http://docs.readthedocs.io/en/latest/theme.html) in documentation
- Fix version number in History to match actual version being released.