### PR TITLE
Remove assignee from .pyup.yml

### DIFF
--- a/.pyup.yml
+++ b/.pyup.yml
@@ -2,7 +2,5 @@ update: all
 pin: True
 branch: development
 schedule: "every week on monday"
-assignees: 
-  - jambonrose
 branch_prefix: update/
 pr_prefix: "[PyUp]"


### PR DESCRIPTION
Using assignee requires private repository permissions. Disabling for
the moment.