### PR TITLE
🔧 Switch PyUp to monthly updates; use emoji prefix

### DIFF
--- a/.pyup.yml
+++ b/.pyup.yml
@@ -1,6 +1,6 @@
 update: all
 pin: True
 branch: development
-schedule: "every week on monday"
+schedule: "every month"
 branch_prefix: update/
-pr_prefix: "[PyUp]"
+pr_prefix: "❗️ "


### PR DESCRIPTION
This package is small and stable enough that it doesn't need the scheduled weekly updates currently provided by (the incredibly helpful) PyUp. This switches the bot to run on a monthly basis (and hopefully lighten the load of my inbox just a little bit).

This also switches the prefix used by PyUp to use an emoji. For reasons.