### PR TITLE
Fix deprecation warnings.

### DIFF
--- a/mdx_subscript.py
+++ b/mdx_subscript.py
@@ -30,8 +30,7 @@ def makeExtension(*args, **kwargs):  # noqa: N802
 class SubscriptExtension(Extension):
     """Extension: text between ~ characters will be subscripted."""
 
-    def extendMarkdown(self, md, md_globals):  # noqa: N802
-        """Insert 'subscript' pattern before 'not_strong' pattern."""
-        md.inlinePatterns.add(
-            "subscript", SimpleTagPattern(SUBSCRIPT_RE, "sub"), "<not_strong"
-        )
+    def extendMarkdown(self, md):  # noqa: N802
+        """Insert 'subscript' pattern."""
+        # Priority of 75 corresponds to a place before the not_strong pattern
+        md.inlinePatterns.register(SimpleTagPattern(SUBSCRIPT_RE, "sub"), "subscript", 75)


### PR DESCRIPTION
This PR fixes some DeprecationWarnings when using a recent version of Markdown (and such warnings are enabled using `-W always::DeprecationWarning`).

```
DeprecationWarning: Using the add method to register a processor or pattern is deprecated. Use the `register` method instead.
  md.inlinePatterns.add(
```

```
DeprecationWarning: The 'md_globals' parameter of 'mdx_subscript.SubscriptExtension.extendMarkdown' is deprecated.
  ext._extendMarkdown(self)
```

See https://python-markdown.github.io/extensions/api/#registries for more info.